### PR TITLE
Minor tweaks to ensure correctness

### DIFF
--- a/.sqlx/query-0991a51e4b448397a9ee80ddf582b02912054edf205087f0f3b8b8a138856e1b.json
+++ b/.sqlx/query-0991a51e4b448397a9ee80ddf582b02912054edf205087f0f3b8b8a138856e1b.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM Tags WHERE Tag = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "0991a51e4b448397a9ee80ddf582b02912054edf205087f0f3b8b8a138856e1b"
+}

--- a/Readme.md
+++ b/Readme.md
@@ -61,3 +61,14 @@ curl -v -X PUT -d '{ "fob_id": "abcd1234", "name": "Peter Mustermann", "contact_
   "contact_data": "Email me: peter@mustermann.de"
 }
 ```
+
+### `DELETE /member/<fob_id>`
+
+Remove an entry for a member.
+
+#### Example
+
+curl -v -X DELETE http://127.0.0.1:8000/api/v1/member/abcd1234
+```json
+{ }
+```

--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ To start the server run
 Retrieves the entry for a specific member using his fob ID.
 
 #### Example
-    curl http://127.0.0.1:8000/api/v1/member/cded8211
+    curl http://127.0.0.1:8000/api/v1/member/abcd1234
 ```json
 {
   "fob_id": "abcd1234",
@@ -56,7 +56,7 @@ Updates an existing entry for a member.
 curl -v -X PUT -d '{ "fob_id": "abcd1234", "name": "Peter Mustermann", "contact_data": "Email me: peter@mustermann.de" }' -H 'Content-Type: application/json' http://127.0.0.1:8000/api/v1/member/abcd1234
 ```json
 {
-  "fob_id": "abc123",
+  "fob_id": "abc1234",
   "name": "Peter Mustermann",
   "contact_data": "Email me: peter@mustermann.de"
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -71,6 +71,9 @@ pub async fn update_member(
     db: &mut Connection<crate::BadgerDB>,
     updated_member: Member,
 ) -> Result<Member> {
+    // Make sure member exists
+    get_member_by_id(db, updated_member.fob_id.clone()).await?;
+
     let tag_number = hex::decode(updated_member.fob_id.to_owned()).map_err(|_| {
         Error::BadRequest("Invalid fob_id, should be formatted as a 4 byte hex".into())
     })?;

--- a/src/database.rs
+++ b/src/database.rs
@@ -16,7 +16,7 @@ pub struct Member {
 }
 
 pub async fn get_member_by_id(
-    mut db: Connection<crate::BadgerDB>,
+    db: &mut Connection<crate::BadgerDB>,
     fob_id: String,
 ) -> Result<Member> {
     let tag_number = hex::decode(fob_id).map_err(|_| {
@@ -27,7 +27,7 @@ pub async fn get_member_by_id(
         "SELECT Tag, Name, Comment FROM Tags WHERE Tag = ?",
         tag_number
     )
-    .fetch_one(&mut **db)
+    .fetch_one(&mut ***db)
     .await?;
 
     Ok(Member {
@@ -37,7 +37,7 @@ pub async fn get_member_by_id(
     })
 }
 
-pub async fn has_member_by_id(mut db: Connection<crate::BadgerDB>, fob_id: String) -> Result<bool> {
+pub async fn has_member_by_id(db: &mut Connection<crate::BadgerDB>, fob_id: String) -> Result<bool> {
     let member_result = get_member_by_id(db, fob_id).await;
     match member_result {
         Ok(_) => Ok(true),
@@ -47,7 +47,7 @@ pub async fn has_member_by_id(mut db: Connection<crate::BadgerDB>, fob_id: Strin
 }
 
 pub async fn create_member(
-    mut db: Connection<crate::BadgerDB>,
+    db: &mut Connection<crate::BadgerDB>,
     new_member: Member,
 ) -> Result<Member> {
     let tag_number = hex::decode(new_member.fob_id.to_owned()).map_err(|_| {
@@ -60,7 +60,7 @@ pub async fn create_member(
         new_member.name,
         new_member.contact_data
     )
-    .fetch(&mut **db)
+    .fetch(&mut ***db)
     .try_collect::<Vec<_>>()
     .await?;
 
@@ -68,7 +68,7 @@ pub async fn create_member(
 }
 
 pub async fn update_member(
-    mut db: Connection<crate::BadgerDB>,
+    db: &mut Connection<crate::BadgerDB>,
     updated_member: Member,
 ) -> Result<Member> {
     let tag_number = hex::decode(updated_member.fob_id.to_owned()).map_err(|_| {
@@ -81,7 +81,7 @@ pub async fn update_member(
         updated_member.contact_data,
         tag_number,
     )
-    .fetch(&mut **db)
+    .fetch(&mut ***db)
     .try_collect::<Vec<_>>()
     .await?;
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -97,3 +97,23 @@ pub async fn update_member(
 
     Ok(updated_member)
 }
+
+pub async fn delete_member(
+    db: &mut Connection<crate::BadgerDB>,
+    fob_id: String,
+) -> Result<()> {
+    // Make sure member exists
+    get_member_by_id(db, fob_id.clone()).await?;
+
+    let tag_number = &parse_fob_id(&fob_id)?[..];
+
+    let results = sqlx::query!(
+        "DELETE FROM Tags WHERE Tag = ?",
+        tag_number
+    )
+    .fetch(&mut ***db)
+    .try_collect::<Vec<_>>()
+    .await?;
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ pub use self::error::{Error, Result};
 
 use crate::database::Member;
 
-use rocket::response::status::Created;
+use rocket::response::status::{Created, NoContent};
 use rocket::serde::json::{json, Json, Value};
 use rocket_db_pools::{sqlx, Connection, Database};
 use sqlx::Acquire;
@@ -49,6 +49,13 @@ async fn update_member(
     Ok(Json(result))
 }
 
+#[delete("/member/<fob_id>")]
+async fn delete_member(mut db: Connection<BadgerDB>, fob_id: &str) -> Result<NoContent> {
+    database::delete_member(&mut db, fob_id.into()).await?;
+
+    Ok(NoContent)
+}
+
 #[catch(404)]
 fn general_not_found() -> Value {
     json!({
@@ -62,5 +69,5 @@ fn general_not_found() -> Value {
 fn rocket() -> _ {
     rocket::build()
         .attach(BadgerDB::init())
-        .mount("/api/v1", routes![get_member, create_member, update_member])
+        .mount("/api/v1", routes![get_member, create_member, update_member, delete_member])
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,14 +39,14 @@ async fn update_member(
     db: Connection<BadgerDB>,
     fob_id: &str,
     member_data: Json<Member>,
-) -> Result<Created<Json<Member>>> {
+) -> Result<Json<Member>> {
     let member = member_data.0;
     if member.fob_id != fob_id {
         return Err(Error::BadRequest("invalid fob_id in member data".into()));
     }
     let result = database::update_member(db, member).await?;
 
-    Ok(Created::new("/member").body(Json(result)))
+    Ok(Json(result))
 }
 
 #[catch(404)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,25 +18,25 @@ use sqlx::Acquire;
 pub struct BadgerDB(sqlx::SqlitePool);
 
 #[get("/member/<fob_id>")]
-async fn get_member(db: Connection<BadgerDB>, fob_id: &str) -> Result<Json<Member>> {
-    let member = database::get_member_by_id(db, fob_id.into()).await?;
+async fn get_member(mut db: Connection<BadgerDB>, fob_id: &str) -> Result<Json<Member>> {
+    let member = database::get_member_by_id(&mut db, fob_id.into()).await?;
 
     Ok(Json(member))
 }
 
 #[post("/member", data = "<member>")]
 async fn create_member(
-    db: Connection<BadgerDB>,
+    mut db: Connection<BadgerDB>,
     member: Json<Member>,
 ) -> Result<Created<Json<Member>>> {
-    let result = database::create_member(db, member.0).await?;
+    let result = database::create_member(&mut db, member.0).await?;
 
     Ok(Created::new("/member").body(Json(result)))
 }
 
 #[put("/member/<fob_id>", data = "<member_data>")]
 async fn update_member(
-    db: Connection<BadgerDB>,
+    mut db: Connection<BadgerDB>,
     fob_id: &str,
     member_data: Json<Member>,
 ) -> Result<Json<Member>> {
@@ -44,7 +44,7 @@ async fn update_member(
     if member.fob_id != fob_id {
         return Err(Error::BadRequest("invalid fob_id in member data".into()));
     }
-    let result = database::update_member(db, member).await?;
+    let result = database::update_member(&mut db, member).await?;
 
     Ok(Json(result))
 }


### PR DESCRIPTION
Only allow 4-byte fob IDs, and report failure when updating a non-existent fob.